### PR TITLE
[#10] Added tables prefix support for webhosts with single database and multiple applications

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,6 +45,7 @@
     },
     "scripts": {
         "post-install-cmd": [
+            "composer dump-autoload -o",
             "bash ./bin/migrations.sh migrate",
             "bash ./bin/migrations.sh migrate -e dev",
             "bash ./bin/migrations.sh migrate -e test",
@@ -52,6 +53,7 @@
             "bower install"
         ],
         "post-update-cmd": [
+            "composer dump-autoload -o",
             "bash ./bin/migrations.sh migrate",
             "bash ./bin/migrations.sh migrate -e dev",
             "bash ./bin/migrations.sh migrate -e test",

--- a/config/dev.php
+++ b/config/dev.php
@@ -22,6 +22,11 @@ $app = require __DIR__ . '/prod.php';
 // enable the debug mode
 $app['debug'] = true;
 
+// prefix table names (optionally)
+$dbOptions = $app['db.options'];
+$dbOptions['prefix'] = 'wfr_';
+$app['db.options'] = $dbOptions;
+
 if (is_file(__DIR__ . '/dev.custom.php')) {
     require __DIR__ . '/dev.custom.php';
 }
@@ -33,6 +38,7 @@ if (is_array($app)) {
 
 $app->register(new \Silex\Provider\TwigServiceProvider());
 
+// this will dump the container to the file, so the IDE could statically recognize classes registered in the container
 //$app->register(new Sorien\Provider\PimpleDumpProvider());
 //$app['pimpledump.output_dir'] = __DIR__ . '/../';
 //$app['pimpledump.trigger_route_pattern'] = '/_dump_pimple';

--- a/docs/Multiple-Applications-In-One-Database.md
+++ b/docs/Multiple-Applications-In-One-Database.md
@@ -1,0 +1,46 @@
+Multiple applications in one database
+=====================================
+
+To configure `Wolnościowiec File Repository` to be in the same database next to
+other application tables there is a possibility to prefix all tables.
+
+The prefix could be defined in the environment configuration.
+
+```
+// prefix table names (optionally)
+$dbOptions = $app['db.options'];
+$dbOptions['prefix'] = 'wfr_';
+$app['db.options'] = $dbOptions;
+```
+
+To override environment configuration settings just create a file in the `config` directory
+with name of the environment suffixed with `.custom.php`
+
+Examples:
+- `config/prod.custom.php`
+- `config/dev.custom.php`
+- `config/test.custom.php`
+
+Example of `prod.custom.php` file:
+
+```
+<?php
+
+$app['api.key'] = 'my-secret-key-is-here-and-this-file-is-ignored-on-git-and-accesible-only-on-production';
+$app['https.force'] = true;
+
+$dbOptions = $app['db.options'];
+$dbOptions['prefix'] = 'wfr_';
+$app['db.options'] = $dbOptions;
+
+return $app;
+```
+
+Note
+----
+
+Changing the prefix on existing database structure may result in not properly working rollback in migrations.
+
+### Development side
+
+Every new migration must extend the `BaseMigration` class and use `createTableName()` method to be compatible with enabled prefix.

--- a/migrations/20161102061430_registry_table.php
+++ b/migrations/20161102061430_registry_table.php
@@ -1,12 +1,10 @@
 <?php
 
-use Phinx\Migration\AbstractMigration;
-
 /**
  * Initial migration that is creating a basic structure
  * for FileRegistry
  */
-class RegistryTable extends AbstractMigration
+class RegistryTable extends BaseMigration
 {
     /**
      * More information on writing migrations is available here:
@@ -27,7 +25,7 @@ class RegistryTable extends AbstractMigration
      */
     public function change()
     {
-        $table = $this->table('file_registry');
+        $table = $this->table($this->createTableName('file_registry'));
         $table->addColumn('fileName', 'string', [
             'length' => 64,
             'null'   => false,

--- a/migrations/20170203193950_tokens.php
+++ b/migrations/20170203193950_tokens.php
@@ -1,15 +1,13 @@
 <?php
 
-use Phinx\Migration\AbstractMigration;
-
 /**
  * @see Token
  */
-class Tokens extends AbstractMigration
+class Tokens extends BaseMigration
 {
     public function up()
     {
-        $table = $this->table('tokens', ['id' => false]);
+        $table = $this->table($this->createTableName('tokens'), ['id' => false]);
 
         $table->addColumn('id', 'string', [
             'length' => 36,
@@ -29,7 +27,7 @@ class Tokens extends AbstractMigration
 
     public function down()
     {
-        $table = $this->table('tokens');
+        $table = $this->table($this->createTableName('tokens'));
         $table->drop();
     }
 }

--- a/migrations/20170208202526_tags.php
+++ b/migrations/20170208202526_tags.php
@@ -1,12 +1,10 @@
 <?php
 
-use Phinx\Migration\AbstractMigration;
-
-class Tags extends AbstractMigration
+class Tags extends BaseMigration
 {
     public function change()
     {
-        $table = $this->table('tags', [
+        $table = $this->table($this->createTableName('tags'), [
             'id' => false,
             'primary_key' => ['id'],
         ]);
@@ -19,10 +17,10 @@ class Tags extends AbstractMigration
         ]);
 
         $table->addColumn('dateAdded', 'datetime');
-        $table->save();
+        $table->create();
 
 
-        $middleTable = $this->table('file_tags', [
+        $middleTable = $this->table($this->createTableName('file_tags'), [
             'id' => false,
             'primary_key' => ['file_id', 'tag_id'],
         ]);
@@ -33,6 +31,6 @@ class Tags extends AbstractMigration
             'length' => 36,
         ]);
 
-        $middleTable->save();
+        $middleTable->create();
     }
 }

--- a/migrations/20170209182645_token_data.php
+++ b/migrations/20170209182645_token_data.php
@@ -1,13 +1,11 @@
 <?php
 
-use Phinx\Migration\AbstractMigration;
-
-class TokenData extends AbstractMigration
+class TokenData extends BaseMigration
 {
     public function change()
     {
-        $table = $this->table('tokens');
+        $table = $this->table($this->createTableName('tokens'));
         $table->addColumn('data', 'text');
-        $table->save();
+        $table->update();
     }
 }

--- a/migrations/BaseMigration.php
+++ b/migrations/BaseMigration.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+abstract class BaseMigration extends AbstractMigration
+{
+    protected function getTableNamePrefix()
+    {
+        return $GLOBALS['app']['db.options']['prefix'] ?? '';
+    }
+
+    protected function createTableName(string $tableName)
+    {
+        return $this->getTableNamePrefix() . $tableName;
+    }
+}

--- a/phinx.php
+++ b/phinx.php
@@ -1,5 +1,8 @@
 <?php
 
+require_once __DIR__ . '/migrations/BaseMigration.php';
+require_once __DIR__ . '/src/app.php';
+
 /**
  * Default migrations configuration
  * -------------------------------
@@ -13,12 +16,7 @@ $config = [
 
     'environments' => [
         'default_migration_table' => 'core_migrations',
-        'default_database'        => 'default',
-        'default' => [
-            'adapter' => 'sqlite',
-            'name'    => __DIR__ . '/data/database_prod.sqlite3',
-        ],
-
+        'default_database'        => 'prod',
         'prod' => [
             'adapter' => 'sqlite',
             'name'    => __DIR__ . '/data/database_prod.sqlite3',
@@ -39,5 +37,20 @@ $config = [
 if (is_file('./phinx.custom.php')) {
     $config = array_merge($config, require './phinx.custom.php');
 }
+
+// get the environment name that was selected using --env|-e switch
+$envName = $config['environments']['default_database'] ?? 'prod';
+
+foreach (['-e', '--environment'] as $switchName) {
+    $match = array_search($switchName, $_SERVER['argv']);
+
+    if ($match !== false && isset($_SERVER['argv'][$match + 1])) {
+        $envName = $_SERVER['argv'][$match + 1];
+        break;
+    }
+}
+
+define('ENV', $envName);
+$GLOBALS['app'] = require_once __DIR__ . '/config/' . ENV . '.php';
 
 return $config;

--- a/src/Doctrine/Extension/TablePrefix.php
+++ b/src/Doctrine/Extension/TablePrefix.php
@@ -1,0 +1,41 @@
+<?php declare(strict_types=1);
+
+namespace Doctrine\Extension;
+
+use Doctrine\ORM\Event\LoadClassMetadataEventArgs;
+use Doctrine\ORM\Mapping\ClassMetadataInfo;
+
+/**
+ * Based on official documentation
+ *
+ * @see http://docs.doctrine-project.org/projects/doctrine-orm/en/stable/cookbook/sql-table-prefixes.html
+ */
+class TablePrefix
+{
+    protected $prefix = '';
+
+    public function __construct($prefix)
+    {
+        $this->prefix = (string)$prefix;
+    }
+
+    public function loadClassMetadata(LoadClassMetadataEventArgs $eventArgs)
+    {
+        /* @var $classMetadata \Doctrine\ORM\Mapping\ClassMetadataInfo */
+        $classMetadata = $eventArgs->getClassMetadata();
+
+        if (!$classMetadata->isInheritanceTypeSingleTable() || $classMetadata->getName() === $classMetadata->rootEntityName) {
+            $classMetadata->setPrimaryTable(array(
+                'name' => $this->prefix . $classMetadata->getTableName()
+            ));
+        }
+
+        foreach ($classMetadata->getAssociationMappings() as $fieldName => $mapping) {
+            if ($mapping['type'] == ClassMetadataInfo::MANY_TO_MANY && $mapping['isOwningSide']) {
+                $mappedTableName = $mapping['joinTable']['name'];
+                $classMetadata->associationMappings[$fieldName]['joinTable']['name'] = $this->prefix . $mappedTableName;
+            }
+        }
+    }
+
+}

--- a/src/Doctrine/Extension/TablePrefix.php
+++ b/src/Doctrine/Extension/TablePrefix.php
@@ -7,6 +7,8 @@ use Doctrine\ORM\Mapping\ClassMetadataInfo;
 
 /**
  * Based on official documentation
+ * -------------------------------
+ *   Allows to add prefixes to all tables managed by Doctrine ORM
  *
  * @see http://docs.doctrine-project.org/projects/doctrine-orm/en/stable/cookbook/sql-table-prefixes.html
  */
@@ -14,9 +16,9 @@ class TablePrefix
 {
     protected $prefix = '';
 
-    public function __construct($prefix)
+    public function __construct(string $prefix)
     {
-        $this->prefix = (string)$prefix;
+        $this->prefix = $prefix;
     }
 
     public function loadClassMetadata(LoadClassMetadataEventArgs $eventArgs)
@@ -37,5 +39,4 @@ class TablePrefix
             }
         }
     }
-
 }

--- a/src/Provider/DoctrineTablePrefixServiceProvider.php
+++ b/src/Provider/DoctrineTablePrefixServiceProvider.php
@@ -1,0 +1,35 @@
+<?php declare(strict_types=1);
+
+namespace Provider;
+
+use Pimple\Container;
+use Pimple\ServiceProviderInterface;
+use Doctrine\ORM\Events;
+use Doctrine\Extension\TablePrefix;
+
+/**
+ * Original code from https://github.com/valeriangalliat/doctrine-table-prefix-service-provider
+ */
+class DoctrineTablePrefixServiceProvider implements ServiceProviderInterface
+{
+    public function register(Container $app)
+    {
+        $app['dbs.event_manager'] = $app->extend('dbs.event_manager', function ($managers, $app) {
+            $app['dbs.options.initializer']();
+
+            foreach ($app['dbs.options'] as $name => $options) {
+                if (isset($options['prefix'])) {
+                    $tablePrefix = new TablePrefix($options['prefix']);
+
+                    /* @var $managers \Doctrine\Common\EventManager[] */
+                    $managers[$name]->addEventListener(
+                        Events::loadClassMetadata,
+                        $tablePrefix
+                    );
+                }
+            }
+
+            return $managers;
+        });
+    }
+}

--- a/src/app.php
+++ b/src/app.php
@@ -17,7 +17,7 @@ $app->register(new Silex\Provider\TwigServiceProvider(), [
     'twig.options' => [
         'cache'            => __DIR__.'/../var/cache/twig',
         'strict_variables' => true,
-        'debug'            => in_array(ENV, ['dev', 'test']),
+        'debug'            => !defined('ENV') || in_array(ENV, ['dev', 'test']),
         'autoescape'       => true,
     ]
 ]);

--- a/src/services.php
+++ b/src/services.php
@@ -11,6 +11,8 @@ $app->register(new \Silex\Provider\DoctrineServiceProvider(), [
     'db.options' => $app['db.options'],
 ]);
 
+$app->register(new \Provider\DoctrineTablePrefixServiceProvider());
+
 // services
 $app['service.file.serve'] = function () {
     return new \Service\FileServingService();

--- a/tests/Doctrine/Extension/TablePrefixTest.php
+++ b/tests/Doctrine/Extension/TablePrefixTest.php
@@ -1,0 +1,66 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Doctrine\Extension;
+
+use Doctrine\Extension\TablePrefix;
+use Doctrine\ORM\Event\LoadClassMetadataEventArgs;
+use Doctrine\ORM\Mapping\ClassMetadataInfo;
+use Tests\WolnosciowiecTestCase;
+
+/**
+ * Tests prefixing for main table and for relations
+ *
+ * @see TablePrefix
+ */
+class TablePrefixTest extends WolnosciowiecTestCase
+{
+    public function testLoadClassMetadata()
+    {
+        /**
+         * @var ClassMetadataInfo|\PHPUnit_Framework_MockObject_MockObject $metadata
+         * @var LoadClassMetadataEventArgs|\PHPUnit_Framework_MockObject_MockObject $args
+         */
+        list($args, $metadata) = $this->getPreparedDependencies();
+
+        $metadata->expects($this->once())
+            ->method('setPrimaryTable')
+            ->with([
+                'name' => 'wolnosciowiec_posts',
+            ]);
+
+        $tablePrefix = new TablePrefix('wolnosciowiec_');
+        $tablePrefix->loadClassMetadata($args);
+
+        $this->assertSame('wolnosciowiec_tags', $metadata->associationMappings['tags']['joinTable']['name']);
+    }
+
+    protected function getPreparedDependencies()
+    {
+        $metadata = $this->createMock(ClassMetadataInfo::class);
+        $metadata->method('getTableName')
+            ->willReturn('posts');
+
+        $metadata->method('isInheritanceTypeSingleTable')
+            ->willReturn(false);
+
+        $metadata->method('getAssociationMappings')
+            ->willReturn([
+                'tags' => [
+                    'type' => ClassMetadataInfo::MANY_TO_MANY,
+                    'isOwningSide' => true,
+                    'joinTable' => [
+                        'name' => 'tags',
+                    ]
+                ]
+            ]);
+
+        $args = $this->createMock(LoadClassMetadataEventArgs::class);
+        $args->method('getClassMetadata')
+            ->willReturn($metadata);
+
+        return [
+            $args,
+            $metadata,
+        ];
+    }
+}


### PR DESCRIPTION
Includes:
- Implementation
- Documentation
- Tests
- Configuration example
- Default configuration for `dev` and `test` environment (`prod` have disabled by default this option for compatibility reasons)
- Made a clean up in phinx configuration